### PR TITLE
fix balanceCalculations

### DIFF
--- a/client/src/pages/ClientDetailPage.jsx
+++ b/client/src/pages/ClientDetailPage.jsx
@@ -214,13 +214,13 @@ export default function ClientDetailPage() {
           <p className="text-[#10B981] text-xl font-bold font-['DM_Serif_Display']">{formatKES(totalPaid)}</p>
         </div>
 
-        {/* Outstanding Balance */}
-        <div className="card-premium p-4">
-          <p className="text-[#3D4F6B] text-xs tracking-wider uppercase mb-2">Outstanding Balance</p>
-          <p className={`text-xl font-bold font-['DM_Serif_Display'] ${outstandingBalance < 0 ? 'text-[#10B981]' : outstandingBalance > 0 ? 'text-[#EF4444]' : 'text-[#F0F4FF]'}`}>
-            {formatKES(outstandingBalance)}
-          </p>
-        </div>
+         {/* Outstanding Balance */}
+         <div className="card-premium p-4">
+           <p className="text-[#3D4F6B] text-xs tracking-wider uppercase mb-2">Outstanding Balance</p>
+           <p className={`text-xl font-bold font-['DM_Serif_Display'] ${outstandingBalance < 0 ? 'text-[#EF4444]' : outstandingBalance > 0 ? 'text-[#10B981]' : 'text-[#F0F4FF]'}`}>
+             {formatKES(outstandingBalance)}
+           </p>
+         </div>
 
         {/* Days Admitted */}
         <div className="card-premium p-4">
@@ -418,12 +418,12 @@ export default function ClientDetailPage() {
                   <span className="text-[#3D4F6B] text-xs tracking-wide uppercase">Total Paid</span>
                   <span className="text-[#10B981] text-sm font-mono text-right">{formatKES(billing?.totalPaid)}</span>
                 </div>
-                <div className="flex items-start justify-between">
-                  <span className="text-[#3D4F6B] text-xs tracking-wide uppercase">Current Balance</span>
-                  <span className={`text-sm font-mono text-right ${billing?.balance < 0 ? 'text-[#10B981]' : billing?.balance > 0 ? 'text-[#EF4444]' : 'text-[#F0F4FF]'}`}>
-                    {formatKES(billing?.balance)}
-                  </span>
-                </div>
+                 <div className="flex items-start justify-between">
+                   <span className="text-[#3D4F6B] text-xs tracking-wide uppercase">Current Balance</span>
+                   <span className={`text-sm font-mono text-right ${billing?.balance < 0 ? 'text-[#EF4444]' : billing?.balance > 0 ? 'text-[#10B981]' : 'text-[#F0F4FF]'}`}>
+                     {formatKES(billing?.balance)}
+                   </span>
+                 </div>
               </div>
             </div>
 

--- a/server/utils/billingEngine.js
+++ b/server/utils/billingEngine.js
@@ -91,20 +91,20 @@ function computeBillingState(client, payments = []) {
   });
   totalCharged += month1Total;
 
-  // ── Months 2 → agreedDurationMonths ─────────────────────────────────
-  for (let m = 2; m <= client.agreedDurationMonths; m++) {
-    const dueDate = addDays(admission, m * 30);
-    if (isBefore(dueDate, addDays(endDate, 1))) {
-      breakdown.push({
-        label: `Month ${m} – Monthly Fee`,
-        amount: effectiveMonthlyFee,
-        dueDate,
-        type: 'monthly_fee',
-        periodKey: `M${m}`
-      });
-      totalCharged += effectiveMonthlyFee;
-    }
-  }
+   // ── Months 2 → agreedDurationMonths ─────────────────────────────────
+   for (let m = 2; m <= client.agreedDurationMonths; m++) {
+     const dueDate = addDays(admission, (m - 1) * 30);
+     if (isBefore(dueDate, addDays(endDate, 1))) {
+       breakdown.push({
+         label: `Month ${m} – Monthly Fee`,
+         amount: effectiveMonthlyFee,
+         dueDate,
+         type: 'monthly_fee',
+         periodKey: `M${m}`
+       });
+       totalCharged += effectiveMonthlyFee;
+     }
+   }
 
   // ── Post-expiry daily charges ────────────────────────────────────────
   let daysPostExpiry = 0;
@@ -128,9 +128,12 @@ function computeBillingState(client, payments = []) {
     }
   }
 
-  // ── Totals ───────────────────────────────────────────────────────────
-  const totalPaid = payments.reduce((sum, p) => sum + p.amount, 0);
-  const balance = totalPaid - totalCharged; // positive = credit, negative = owes
+   // ── Totals ───────────────────────────────────────────────────────────
+   const totalPaid = payments.reduce((sum, p) => sum + p.amount, 0);
+   // balance is always running total: positive = credit, negative = owes
+   // unpaid months automatically carry forward since totalCharged 
+   // accumulates all elapsed periods
+   const balance = totalPaid - totalCharged;
 
   return {
     totalCharged,
@@ -189,10 +192,10 @@ function getAlertsForClient(client, payments = []) {
     });
   }
 
-  // MONTHLY_FEE_DUE – 5 days after each 30-day mark within agreed duration
-  for (let m = 2; m <= client.agreedDurationMonths; m++) {
-    const dueDay = m * 30;
-    if (daysElapsed >= dueDay + 5 && daysElapsed <= dueDay + 10) {
+   // MONTHLY_FEE_DUE – 5 days after each 30-day mark within agreed duration
+   for (let m = 2; m <= client.agreedDurationMonths; m++) {
+     const dueDay = (m - 1) * 30;
+     if (daysElapsed >= dueDay + 5 && daysElapsed <= dueDay + 10) {
       const monthCharged = billing.breakdown
         .filter(b => b.periodKey === `M${m}`)
         .reduce((s, b) => s + b.amount, 0);
@@ -256,3 +259,5 @@ module.exports = {
   parseCommentDirectives,
   DAILY_RATE
 };
+
+


### PR DESCRIPTION
1. Fixed Month 2+ due dates in server/utils/billingEngine.js:
Line 96: Changed const dueDate = addDays(admission, m * 30); to const dueDate = addDays(admission, (m - 1) * 30);
This fixes the issue where Month 2 was incorrectly due on Day 60 instead of Day 30

2. Added balance calculation comment in server/utils/billingEngine.js:
Lines 133-135: Added explanatory comments confirming that balance is a running total and unpaid months carry forward automatically

3. Fixed MONTHLY_FEE_DUE alert trigger in server/utils/billingEngine.js:
Line 197: Changed const dueDay = m * 30; to const dueDay = (m - 1) * 30;
This ensures alerts fire 5 days after the actual (now corrected) due date

4. Fixed balance colors in client/src/pages/ClientDetailPage.jsx:
Line 220: Outstanding Balance color logic swapped to show red for negative balance (owed) and green for positive balance (credit)
Line 423: Current Balance color logic in Fee Structure section fixed with same swap



closes #26 